### PR TITLE
chore: add engine property in package.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
 	"editor.formatOnSave": true,
-	"editor.defaultFormatter": "biomejs.biome"
+	"editor.defaultFormatter": "biomejs.biome",
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "node-styles",
 	"version": "0.1.0",
 	"description": "",
-  "license": "(MIT OR Apache-2.0)",
+	"license": "(MIT OR Apache-2.0)",
 	"main": "src/main.mjs",
 	"scripts": {
 		"format": "biome format --write",
@@ -14,5 +14,9 @@
 		"@types/node": "^22.4.0",
 		"chalk": "^5.3.0",
 		"vitest": "^2.0.5"
-	}
+	},
+	"engines": {
+		"node": ">=21"
+	},
+	"engineStrict": true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,16 +994,17 @@ snapshots:
 
   vite@5.4.1(@types/node@22.4.0):
     dependencies:
+      '@types/node': 22.4.0
       esbuild: 0.21.5
       postcss: 8.4.41
       rollup: 4.20.0
     optionalDependencies:
-      '@types/node': 22.4.0
       fsevents: 2.3.3
 
   vitest@2.0.5(@types/node@22.4.0):
     dependencies:
       '@ampproject/remapping': 2.3.0
+      '@types/node': 22.4.0
       '@vitest/expect': 2.0.5
       '@vitest/pretty-format': 2.0.5
       '@vitest/runner': 2.0.5
@@ -1022,8 +1023,6 @@ snapshots:
       vite: 5.4.1(@types/node@22.4.0)
       vite-node: 2.0.5(@types/node@22.4.0)
       why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.4.0
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
Added an `engine` property in package.json since `styleText` has been introcude in Node `v20.12.0`.